### PR TITLE
リアルタイムチャット機能のテスト記載修正

### DIFF
--- a/spec/factories/live_rooms.rb
+++ b/spec/factories/live_rooms.rb
@@ -3,6 +3,5 @@
 FactoryBot.define do
   factory :live_room do
     name { "Test Live Room" } # 必要に応じてデフォルト値を設定
-    association :user # 必要であれば関連付けを設定
   end
 end


### PR DESCRIPTION
## 概要
- リアルタイムチャット機能のテストコードの修正

## 変更内容
① `spec/channels/live_room_channel_spec.rb`の修正と追記

## 実装中のエラー
無し

## その他
- 不足分の記載できた。
- ブラウザ上で全ての挙動の確認済み